### PR TITLE
Add a convenience playbook that runs all required playbooks

### DIFF
--- a/ansible/all.yml
+++ b/ansible/all.yml
@@ -1,0 +1,26 @@
+---
+- hosts: all
+  tasks:
+  - name: Import variables
+    include_vars:
+      dir: ../etc/kolla
+      extensions: ['yml']
+      ignore_files:
+        - passwords.yml.original
+        - globals.yml.original
+
+- include: kolla-host.yml
+  vars:
+    action: bootstrap-servers
+
+- include: site.yml
+  vars:
+    action: deploy
+
+- include: post-deploy.yml
+  vars:
+    action: deploy
+
+- include: post-deploy-contrail.yml
+  vars:
+    action: deploy


### PR DESCRIPTION
This playbook will run all the required playbooks thereby avoiding running multiple playbooks required to provision open stack.