### PR TITLE
Add default values for compute_init and neutron_init containers

### DIFF
--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -21,6 +21,12 @@ disable_nova_compute_service: "no"
 # neutron plugin. "no" means pure openstack neutron - without contrail neutron plugin
 enable_neutron_opencontrail: "yes"
 
+# When enable_neutron_opencontrail is set to "yes", then these two variables are
+# required. By default these are being set to known working container images.
+# These should be overridden in globals.yml
+neutron_opencontrail_init_image_full: "opencontrailnightly/contrail-openstack-neutron-init:master-20180131150536-centos7-ocata"
+nova_compute_opencontrail_init_image_full: "opencontrailnightly/contrail-openstack-compute-init:master-20180131150536-centos7-ocata"
+
 # contrail_additions : Ideally leave this to yes if you want the opencontrail
 # heat plugin. "no" means pure openstack heat - without contrail heat plugin
 enable_heat_opencontrail: "yes"

--- a/etc/kolla/globals.yml
+++ b/etc/kolla/globals.yml
@@ -344,4 +344,5 @@ tempest_floating_network_name:
 
 # tempest_image_alt_id: "{{ tempest_image_id }}"
 # tempest_flavor_ref_alt_id: "{{ tempest_flavor_ref_id }}"
-
+# neutron_opencontrail_init_image_full: "opencontrailnightly/contrail-openstack-neutron-init:master-20180131150536-centos7-ocata"
+# nova_compute_opencontrail_init_image_full: "opencontrailnightly/contrail-openstack-compute-init:master-20180131150536-centos7-ocata"


### PR DESCRIPTION
Setting these values is required to get past CI errors when these values are not
being set
neutron_opencontrail_init_image_full: "opencontrailnightly/contrail-openstack-neutron-init:master-20180131150536-centos7-ocata"
nova_compute_opencontrail_init_image_full: "opencontrailnightly/contrail-openstack-compute-init:master-20180131150536-centos7-ocata"