### PR TITLE
Fix for CI break - set contrail_extensions in ContrailPlugin.ini

### DIFF
--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -59,6 +59,8 @@ ironic_cleaning_network: "ironic-provision"
 enable_contrail_horizon: "no"
 opencontrail_api_server_ip: "{{ contrail_api_interface_address }}"
 opencontrail_api_server_port: "8082"
+opencontrail_collector_ip: "{{ contrail_api_interface_address }}"
+opencontrail_collector_port: "8081"
 
 ####################### CONTRAIL ADDITIONS - END ###########################
 

--- a/ansible/roles/neutron/templates/ContrailPlugin.ini.j2
+++ b/ansible/roles/neutron/templates/ContrailPlugin.ini.j2
@@ -3,6 +3,11 @@
 api_server_ip = {{ opencontrail_api_server_ip }}
 api_server_port = {{ opencontrail_api_server_port }}
 multi_tenancy = True
+contrail_extensions = ipam:neutron_plugin_contrail.plugins.opencontrail.contrail_plugin_ipam.NeutronPluginContrailIpam,policy:neutron_plugin_contrail.plugins.opencontrail.contrail_plugin_policy.NeutronPluginContrailPolicy,route-table:neutron_plugin_contrail.plugins.opencontrail.contrail_plugin_vpc.NeutronPluginContrailVpc,contrail:None,service-interface:None,vf-binding:None
+
+[COLLECTOR]
+analytics_api_ip = {{ opencontrail_collector_ip }}
+analytics_api_port = {{ opencontrail_collector_port }}
 
 [keystone_authtoken]
 auth_host = {{ kolla_internal_fqdn }}


### PR DESCRIPTION
Set appropriate value for contrail_extensions and also add the [COLLECTOR]
section in ContrailPlugin.ini template. Also add default values for the relevant
variables used in the template