### PR TITLE
Update default settings in libvirtd.conf jinja template

### DIFF
--- a/ansible/roles/nova/templates/libvirtd.conf.j2
+++ b/ansible/roles/nova/templates/libvirtd.conf.j2
@@ -1,4 +1,5 @@
 listen_tcp = 1
+listen_tls = 0
 auth_tcp = "none"
 ca_file = ""
 log_level = 3


### PR DESCRIPTION
Existing defaults are setup for tcp, and set ca_file to an empty string.
'If you set this to an empty string, then no trusted CA certificate is loaded.'

libvirt may complain 'unsupported configuration: No server certificate path
set to match server key', as such tls should also be explicitly set to 0.

Change-Id: I49c64808cb236dab1d9fa2e699d0a2f2fc54cc99
(cherry picked from commit 24427735dae38206fcc1615c4dfee88d6999ffb6)